### PR TITLE
Fix bug where only the first character of the bridge/processor's IP a…

### DIFF
--- a/pylutron_caseta/cli.py
+++ b/pylutron_caseta/cli.py
@@ -129,7 +129,7 @@ async def lap_pair(address: str, cacert: TextIO, cert: TextIO, key: TextIO):
             "pairing."
         )
 
-    data = await async_pair(address[0], _ready)
+    data = await async_pair(address, _ready)
     cacert.write(data["ca"])
     cert.write(data["cert"])
     key.write(data["key"])


### PR DESCRIPTION
Fix bug where only the first character of the bridge/processor's IP address is used for pairing from CLI.

Successfully tested with QSX processor:

```
$ lap-pair 192.168.1.97
Press the small black button on the back of the bridge to complete pairing.
Successfully paired with 3.223
```