### PR TITLE
Add support for HomeWorks QSX systems

### DIFF
--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -24,6 +24,7 @@ _LEAP_DEVICE_TYPES = {
         "SunnataSwitch",
         "TempInWallPaddleSwitch",
         "Switched",
+        "KeypadLED",
     ],
     "fan": [
         "CasetaFanSpeedController",
@@ -65,6 +66,11 @@ _LEAP_DEVICE_TYPES = {
         "GrafikTHybridKeypad",
         "AlisseKeypad",
         "PalladiomKeypad",
+        "PalladiomKeypad_2Button"
+        "PalladiomKeypad_3Button"
+        "PalladiomKeypad_3ButtonRaiseLower"
+        "PalladiomKeypad_4Button"
+        "HomeownerKeypad",
     ],
 }
 

--- a/pylutron_caseta/__init__.py
+++ b/pylutron_caseta/__init__.py
@@ -13,6 +13,7 @@ _LEAP_DEVICE_TYPES = {
         "TempInWallPaddleDimmer",
         "WallDimmerWithPreset",
         "Dimmed",
+        "SpectrumTune", # Ketra lamps
     ],
     "switch": [
         "WallSwitch",

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -601,9 +601,10 @@ class Smartbridge:
                         )
                         self._handle_one_zone_status(response)
 
-            elif (project["ProductType"] == "Lutron RadioRA 3 Project") :
-                # RadioRa3 Bridge (processor) Device detected
-                _LOG.debug("RA3 bridge detected")
+            elif (project["ProductType"] == "Lutron RadioRA 3 Project"
+                  or project["ProductType"] == "Lutron HWQS Project"):
+                # RadioRa3 or QSX Bridge (processor) Device detected
+                _LOG.debug("RA3 or QSX bridge detected")
 
                 # Load processor as devices[1] for compatibility with lutron_caseta HA integration
                 await self._load_ra3_processor()

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -297,6 +297,37 @@ class Smartbridge:
         zone_id = device.get("zone")
         if not zone_id:
             return
+        
+        # Handle Ketra lamps
+        if device.get("type") == "SpectrumTune":
+            if fade_time is not None:
+                await self._request(
+                    "CreateRequest",
+                    f"/zone/{zone_id}/commandprocessor",
+                    {
+                        "Command": {
+                            "CommandType": "GoToSpectrumTuningLevel",
+                            "SpectrumTuningLevelParameters": {
+                                "Level": value,
+                                "FadeTime": _format_duration(fade_time),
+                            },
+                        }
+                    },
+                )
+            else:
+                await self._request(
+                    "CreateRequest",
+                    f"/zone/{zone_id}/commandprocessor",
+                    {
+                        "Command": {
+                            "CommandType": "GoToSpectrumTuningLevel",
+                            "SpectrumTuningLevelParameters": {
+                                "Level": value
+                            },
+                        }
+                    },
+                )
+            return
 
         if device.get("type") in _LEAP_DEVICE_TYPES["light"] and fade_time is not None:
             await self._request(

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -917,7 +917,7 @@ class Smartbridge:
                 "button_group": parent_id,
             },
         ).update(
-            name="_".join((area["name"], station_name, button_name, device["name"])),
+            name="_".join((area["name"], station_name, button_name)),
             type=device["type"],
             model=device["model"],
             serial="_".join(("lcra3",str(self.devices["1"]["serial"]),str(button_id),str(button_number))),

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -475,6 +475,19 @@ class Smartbridge:
                 {"Command": {"CommandType": "PressAndRelease"}},
             )
 
+    async def tap_button(self, button_id: str):
+        """
+        Sends a press and release message for the given button ID.
+
+        :param button_id: button ID, e.g. 23
+        """
+        if button_id in self.buttons:
+            await self._request(
+                "CreateRequest",
+                f"/button/{button_id}/commandprocessor",
+                {"Command": {"CommandType": "PressAndRelease"}},
+            )
+
     def _get_zone_id(self, device_id: str) -> Optional[str]:
         """
         Return the zone id for an given device.

--- a/pylutron_caseta/smartbridge.py
+++ b/pylutron_caseta/smartbridge.py
@@ -539,7 +539,8 @@ class Smartbridge:
         tilt = status.get("Tilt", None)
         _LOG.debug("zone=%s level=%s", zone, level)
         device = self.get_device_by_zone_id(zone)
-        device["current_state"] = level
+        if level >= 0:
+            device["current_state"] = level
         device["fan_speed"] = fan_speed
         device["tilt"] = tilt
         if device["device_id"] in self._subscribers:


### PR DESCRIPTION
- Add support for QSX processors by including their ProjectType string. Tested against QSX processor in HomeAssistant dev environment.
- Add baseline support for Ketra lamps by adding `SpectrumTune` to the `light` section of `_LEAP_DEVICE_TYPES`, and for dimming them by adding `GoToSpectrumTuningLevel` support to `set_value()`.
- Fix a bug where when the color/color temperature of a Ketra lamp changes, the `ColorTuningStatus` message does not contain a `Level` attribute and pylutron-caseta incorrectly assumes that means the zone is off.
- Add support for keypad button LEDs (creates switch devices for each button LED, subscribes to state from processor, and turns LEDs on and off from Home Assistant state changes).
- Add `tap_button` function to send keypad button presses to the processor. This providers the necessary support to add button entities into the `lutron_caseta` Home Assistant component.